### PR TITLE
fix(hydro_optimize): Fix case where some nodes' cardinalities were not tracked correctly; …

### DIFF
--- a/hydro_optimize/src/deploy_and_analyze.rs
+++ b/hydro_optimize/src/deploy_and_analyze.rs
@@ -52,6 +52,7 @@ fn insert_counter_node(node: &mut HydroNode, next_stmt_id: &mut usize, duration:
         | HydroNode::ReduceKeyedWatermark { metadata, .. }
         | HydroNode::Network { metadata, .. }
         | HydroNode::ExternalInput { metadata, .. }
+        | HydroNode::SingletonSource { metadata, .. }
          => {
             let metadata = metadata.clone();
             let node_content = std::mem::replace(node, HydroNode::Placeholder);
@@ -77,7 +78,6 @@ fn insert_counter_node(node: &mut HydroNode, next_stmt_id: &mut usize, duration:
         | HydroNode::Sort { .. }
         | HydroNode::Cast { .. }
         | HydroNode::ObserveNonDet { .. }
-        | HydroNode::SingletonSource { .. } // Cardinality = 1
         | HydroNode::BeginAtomic { .. }
         | HydroNode::EndAtomic { .. }
         | HydroNode::Batch { .. }


### PR DESCRIPTION
…later passes would check the hashmap of counters for that machine only and erase cardinalities for nodes on other machines.

Give counter to SingletonSource (which may have a singleton per tick).